### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/zKillboard/podmail/security/code-scanning/1](https://github.com/zKillboard/podmail/security/code-scanning/1)

The best way to fix the problem is to explicitly specify the required permissions for the job (or entire workflow) via a `permissions` block. For this workflow, the deployment step requires write access to repository contents (`contents: write`), but most jobs will only require read. To follow least privilege, define the `permissions` key for the job `deploy` with the minimal required setting. Since only deployment needs `contents: write`, specify:

```yaml
permissions:
  contents: write
```

immediately under the job declaration (line 10, before `runs-on`), so that only the deploy job gets write permission. If later you have more jobs, this only applies to this job. No other changes to functionality are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
